### PR TITLE
fix(tpcc): set prepopulation worker tid

### DIFF
--- a/benchmark/TPCC_bench.hh
+++ b/benchmark/TPCC_bench.hh
@@ -675,6 +675,7 @@ template <typename DBParams>
 class tpcc_access {
 public:
     static void prepopulation_worker(tpcc_db<DBParams> &db, int worker_id) {
+        ::TThread::set_id(worker_id);
         tpcc_prepopulator<DBParams> pop(worker_id, db);
         db.thread_init_all();
         pop.run();


### PR DESCRIPTION
Calling prepopulation_worker() from multiple threads may introduce bugs if a db implementation is dependant of the thread id (such initialize per-thread data)