### PR TITLE
Performance improvement: prevent false sharing

### DIFF
--- a/benchmark/DB_oindex.hh
+++ b/benchmark/DB_oindex.hh
@@ -773,7 +773,10 @@ protected:
 
 private:
     table_type table_;
-    uint64_t key_gen_;
+    union alignas(CACHE_LINE_SIZE) {
+        uint64_t key_gen_;
+        uint8_t _[CACHE_LINE_SIZE];
+    };
 
     static bool
     access_all(std::array<access_t, value_container_type::num_versions>& cell_accesses, std::array<TransItem*,
@@ -1450,8 +1453,10 @@ public:
 
 //private:
     table_type table_;
-    uint64_t key_gen_;
-
+    union alignas(CACHE_LINE_SIZE) {
+        uint64_t key_gen_;
+        uint8_t _[CACHE_LINE_SIZE];
+    };
     //static bool
     //access_all(std::array<access_t, internal_elem::num_versions>&, std::array<TransItem*, internal_elem::num_versions>&, internal_elem*) {
     //    always_assert(false, "Not implemented.");

--- a/benchmark/DB_uindex.hh
+++ b/benchmark/DB_uindex.hh
@@ -84,8 +84,10 @@ private:
     Hash hasher_;
     Pred pred_;
 
-    uint64_t key_gen_;
-
+    union alignas(CACHE_LINE_SIZE) {
+        uint64_t key_gen_;
+        uint8_t _[CACHE_LINE_SIZE];
+    };
     // used to mark whether a key is a bucket (for bucket version checks)
     // or a pointer (which will always have the lower 3 bits as 0)
     static constexpr uintptr_t bucket_bit = C::item_key_tag;
@@ -681,7 +683,10 @@ private:
     Hash hasher_;
     Pred pred_;
 
-    uint64_t key_gen_;
+    union alignas(CACHE_LINE_SIZE) {
+        uint64_t key_gen_;
+        uint8_t _[CACHE_LINE_SIZE];
+    };
 
     // used to mark whether a key is a bucket (for bucket version checks)
     // or a pointer (which will always have the lower 3 bits as 0)


### PR DESCRIPTION
This PR prevents false sharing between writing to `key_gen_` and reading any of the index members (as well as invoking virtual methods).
I noticed a performance hit in rubis benchmark with many threads. I saw a very long `time_commit` value (when enabled the performance measurements). Perf pointed me to reading the virtual table of `ordered_index`. The reason was that some transactions were in the process of committing (and invoking virtual methods of `ordered_index`), while other transactions were incrementing the `key_gen_` member.
The best solution would be to also prevent writing to the same memory location by many threads as it causes contention, but this PR improves current things with minimal changes.
I noticed a huge improvement (in the order of 2x) when running rubis with 64 threads after this change  